### PR TITLE
Fixes #8

### DIFF
--- a/app/Http/Controllers/Api/VerificationController.php
+++ b/app/Http/Controllers/Api/VerificationController.php
@@ -48,7 +48,23 @@ class VerificationController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        //Upload user id or video and verify their account
+        $data = $request-> validate([
+            'image' => ['required', 'image', 'mimes:png,jpg,jpeg', 'max:2048'],
+            'video' => ['required', 'file', 'mimes:mp4', 'max:10048']
+          ]);
+  
+          $imageURL = $data['image']->store('uploads/images', 'public');
+          $videoURL = $data['video']->store('uploads/videos', 'public');
+          return auth()->user()->verification()->create([
+              'photoURL' => $imageURL,
+              'videoURL' => $videoURL,
+              'status' => 1
+          ]);
+        return response()->json([
+          'message' => 'Verification Successful',
+          'data' => $result
+        ], 201);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,6 +42,7 @@ Route::group(['namespace' => 'Api', 'middleware' => 'auth:api',  'prefix' => 'v1
     Route::get('transaction/funder/{id}', 'TransactionController@getFunderHistory');
     Route::post('transaction/store', 'TransactionController@store');
     Route::post('transaction/update/{id}','TransactionController@update');
+    Route::post('save-verification-file','VerificationController@store');
 });
 Route::post('/password/email', 'Api\ForgotPasswordController@sendResetLinkEmail'); //For sending email link
 Route::post('/password/reset', 'Api\ResetPasswordController@reset');  //For resetting the password


### PR DESCRIPTION
I have created an endpoint to upload user ID image and video then verify their account.

A post request with validations. Can only accept images of 'mimes:png,jpg,jpeg', with max size of 2mb 'max:2048' and video (mp4 with max size of 10mb) 'mimes:mp4', 'max:10048'.

http://127.0.0.1:8000/api/v1/save-verification-file

<img width="970" alt="Screenshot 2020-06-29 at 22 25 37" src="https://user-images.githubusercontent.com/26828538/86106318-56216780-bab8-11ea-86ab-b6b8d1ec0dc8.png">

<img width="679" alt="Screenshot 2020-06-29 at 22 26 05" src="https://user-images.githubusercontent.com/26828538/86106676-c334fd00-bab8-11ea-9278-21593f87f5f8.png">

<img width="636" alt="Screenshot 2020-06-29 at 22 51 41" src="https://user-images.githubusercontent.com/26828538/86106595-a8fb1f00-bab8-11ea-8769-a99fb0351247.png">

<img width="427" alt="Screenshot 2020-06-29 at 22 52 09" src="https://user-images.githubusercontent.com/26828538/86106633-b2848700-bab8-11ea-9b3a-b5d439696f68.png">
